### PR TITLE
Interaction updates - part 2 - click anywhere to close image layer

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -6,23 +6,34 @@
   let bearBtn = document.getElementById("bear-button");
   let jockBtn = document.getElementById("jock-button");
 
-  imageContainer.addEventListener("mousemove", e => {
-    root.style.setProperty('--mouse-x', e.pageX - imageContainer.offsetLeft + "px");
-    root.style.setProperty('--mouse-y', e.pageY - imageContainer.offsetTop + "px");
-  });
+  var twinkContainer = document.getElementById("twink-container");
+  var bearContainer = document.getElementById("bear-container");
+  var jockContainer = document.getElementById("jock-container");
 
+  // imageContainer.addEventListener("mousemove", e => {
+  //   root.style.setProperty('--mouse-x', e.pageX - imageContainer.offsetLeft + "px");
+  //   root.style.setProperty('--mouse-y', e.pageY - imageContainer.offsetTop + "px");
+  // });
+
+  // Add images showing when u click on buttons
   twinkBtn.addEventListener("click", e => {
-    var element = document.getElementById("twink-container");
-    element.classList.toggle("sm-twink-images-container--show");
+    twinkContainer.classList.add("sm-twink-images-container--show");
   });
-
   bearBtn.addEventListener("click", e => {
-    var element = document.getElementById("bear-container");
-    element.classList.toggle("sm-bear-images-container--show");
+    bearContainer.classList.add("sm-bear-images-container--show");
+  });
+  jockBtn.addEventListener("click", e => {
+    jockContainer.classList.add("sm-jock-images-container--show");
   });
 
-  jockBtn.addEventListener("click", e => {
-    var element = document.getElementById("jock-container");
-    element.classList.toggle("sm-jock-images-container--show");
+  // Remove images showing when u click on image layers
+  twinkContainer.addEventListener("click", e => {
+    twinkContainer.classList.remove("sm-twink-images-container--show");
+  });
+  bearContainer.addEventListener("click", e => {
+    bearContainer.classList.remove("sm-bear-images-container--show");
+  });
+  jockContainer.addEventListener("click", e => {
+    jockContainer.classList.remove("sm-jock-images-container--show");
   });
 })();


### PR DESCRIPTION
Merging into https://github.com/adarnoo/categories/pull/4

Fixes #3 

@adarnoo this adds logic that once an image layer is showing, if you click it, the class `sm-jock-images-container--show` gets removed (instead of added like via button clicks - but same idea)